### PR TITLE
add mouse up event for PlayerControler in start function

### DIFF
--- a/assets/Scipts/PlayerController.ts
+++ b/assets/Scipts/PlayerController.ts
@@ -21,6 +21,7 @@ export class PlayerController extends Component {
     private _curMoveIndex = 0;
 
     start () {
+        systemEvent.on(SystemEvent.EventType.MOUSE_UP, this.onMouseUp, this);
     }
 
     reset() {


### PR DESCRIPTION
描述：
        使用官网中 快速上手: 制作第一个游戏 的最终代码，游戏运行后，角色不能跳跃

说明：
        官网代码：Cocos 官网 -> 快速上手 -> 制作第一个游戏 -> 最终代码
        文件代码： assets/Scipts/PlayerController.ts 的 start 函数中，没有在开始时添加相应的监听鼠标事件